### PR TITLE
Add mock parameter backend

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@hapi/hapi": "^21.4.0",
+        "@hapi/hoek": "^11.0.7",
         "@hapi/inert": "^7.1.0",
         "@hapi/vision": "^7.0.3",
         "dotenv": "^16.4.7",

--- a/server/package.json
+++ b/server/package.json
@@ -20,10 +20,11 @@
   "description": "",
   "dependencies": {
     "@hapi/hapi": "^21.4.0",
-    "dotenv": "^16.4.7",
-    "hapi-swagger": "^17.3.2",
+    "@hapi/hoek": "^11.0.7",
     "@hapi/inert": "^7.1.0",
     "@hapi/vision": "^7.0.3",
+    "dotenv": "^16.4.7",
+    "hapi-swagger": "^17.3.2",
     "joi": "^17.13.3"
   },
   "devDependencies": {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -71,10 +71,17 @@ export const init = async () => {
         const postmanUrl = `https://postman-echo.com/get?message=${payload.message}`;
         try {
           const response = await fetch(postmanUrl);
-          console.log('response => ', response);
+          // console.log('response => ', response);
           const data = await response.json();
-          console.log('data => ', data);
-          return h.response(data).code(200);
+          // console.log('data => ', data);
+          const message: ReturnMessage = {
+            postmanEcho: JSON.stringify(data),
+            timestamp: Date.now(),
+            env: env.ENV,
+            version: env.VERSION
+          };
+          console.log('h.response => ', h.response(message));
+          return h.response(message).code(200);
         } catch (e) {
           console.error('Error calling Postman: ', e);
           return h.response('Error calling Postman: ' + e).code(500);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -56,7 +56,7 @@ export const init = async () => {
   server.route({
     method: 'POST',
     path: '/ping',
-    handler: (request, h) => {
+    handler: async(request, h) => {
       const payload = request.payload as IncomingMessage;
       if (request.query.mock && request.query.mock === true) {
         const message: ReturnMessage = {
@@ -68,7 +68,17 @@ export const init = async () => {
         return h.response(message).code(200);
       } else {
         // Call postman echo
-        return h;
+        const postmanUrl = `https://postman-echo.com/get?message=${payload.message}`;
+        try {
+          const response = await fetch(postmanUrl);
+          console.log('response => ', response);
+          const data = await response.json();
+          console.log('data => ', data);
+          return h.response(data).code(200);
+        } catch (e) {
+          console.error('Error calling Postman: ', e);
+          return h.response('Error calling Postman: ' + e).code(500);
+        }
       }
     },
     options: {

--- a/server/src/models/message.ts
+++ b/server/src/models/message.ts
@@ -3,7 +3,8 @@ export interface IncomingMessage {
 }
 
 export interface ReturnMessage {
-  message: string,
+  message?: string,
+  postmanEcho?: string,
   timestamp: number,
   env: string,
   version: string


### PR DESCRIPTION
Added functionality to call Postman Echo when a 'mock' query param is missing or false. The response gets mapped to a new optional 'postmanEcho' attribute in ReturnMessage. Also made the 'message' attribute optional since it will only be used when mock=true.

I could have repurposed the 'message' attribute to handle either type of response, but having separate fields makes it cleaner for the frontend to determine which result scenario to display.